### PR TITLE
Use HTTPS for embedded video

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
     <p style="font-size:17px; margin-bottom:-30px" align="left"> This work is supported by the National Science Foundation and won a 2013 Internet2 Innovative Application Award (under the name BBCC)</p>
     <a name="compare" href="#compare"><h2 class="section-heading">Compare PCC and TCP in Action</h2></a>
 <div class="embed-responsive embed-responsive-16by9">
-     <iframe class="embed-responsive-item" src="http://www.youtube.com/embed/l0qYs9BL7Zk?feature=player_detailpage"></iframe>
+     <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/l0qYs9BL7Zk?feature=player_detailpage"></iframe>
 </div>
 
 


### PR DESCRIPTION
YouTube no longer delivers embedded video over plain HTTP so the embedded video should be changed to HTTPS.